### PR TITLE
 enable 'name' query string in wardeploy

### DIFF
--- a/Kudu.Services.Web/App_Start/SwaggerConfig.cs
+++ b/Kudu.Services.Web/App_Start/SwaggerConfig.cs
@@ -27,6 +27,7 @@ namespace Kudu.Services.Web
                         c.OperationFilter<AddFileParamTypes>();
                         c.OperationFilter<NoReservedParam>();
                         c.OperationFilter<AcceptedResponseFilter>();
+						c.OperationFilter<AddQueryStringParam>();
                         c.OperationFilter<QueryParamCantBeObject>();
                     })
                 .EnableSwaggerUi(c =>
@@ -84,6 +85,27 @@ public class AddFileParamTypes : IOperationFilter
             operation.parameters.Insert(0, fileParam);
         }
     }
+}
+
+public class AddQueryStringParam : IOperationFilter
+{
+	public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
+	{
+		var warDeployQueryParam = new Parameter
+		{
+			name = "name",
+			@in = "query",
+			required = false,
+			type = "string"
+		};
+		if (operation.operationId == "PushDeployment_WarPushDeploy")
+		{
+			List<Parameter> parameters = new List<Parameter>();
+			parameters.AddRange(operation.parameters);
+			parameters.Add(warDeployQueryParam);
+			operation.parameters = parameters.ToArray();
+		}
+	}
 }
 
 public class NoReservedParam : IOperationFilter

--- a/Kudu.Services.Web/App_Start/SwaggerConfig.cs
+++ b/Kudu.Services.Web/App_Start/SwaggerConfig.cs
@@ -27,7 +27,7 @@ namespace Kudu.Services.Web
                         c.OperationFilter<AddFileParamTypes>();
                         c.OperationFilter<NoReservedParam>();
                         c.OperationFilter<AcceptedResponseFilter>();
-						c.OperationFilter<AddQueryStringParam>();
+                        c.OperationFilter<AddQueryStringParam>();
                         c.OperationFilter<QueryParamCantBeObject>();
                     })
                 .EnableSwaggerUi(c =>
@@ -89,23 +89,23 @@ public class AddFileParamTypes : IOperationFilter
 
 public class AddQueryStringParam : IOperationFilter
 {
-	public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
-	{
-		var warDeployQueryParam = new Parameter
-		{
-			name = "name",
-			@in = "query",
-			required = false,
-			type = "string"
-		};
-		if (operation.operationId == "PushDeployment_WarPushDeploy")
-		{
-			List<Parameter> parameters = new List<Parameter>();
-			parameters.AddRange(operation.parameters);
-			parameters.Add(warDeployQueryParam);
-			operation.parameters = parameters.ToArray();
-		}
-	}
+    public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
+    {
+        var warDeployQueryParam = new Parameter
+        {
+            name = "name",
+            @in = "query",
+            required = false,
+            type = "string"
+        };
+        if (operation.operationId == "PushDeployment_WarPushDeploy")
+        {
+            List<Parameter> parameters = new List<Parameter>();
+            parameters.AddRange(operation.parameters);
+            parameters.Add(warDeployQueryParam);
+            operation.parameters = parameters.ToArray();
+        }
+    }
 }
 
 public class NoReservedParam : IOperationFilter


### PR DESCRIPTION
The code [here](https://github.com/projectkudu/kudu/blob/54fb4ecaacec93c2d11cfb3c0a294715e147e951/Kudu.Services/Deployment/PushDeploymentController.cs#L99) contains an extra query string param for the `wardeploy` method, but it is not exposed in the method signature to swagger.

Though we can change the signature of `WarPushDeploy()` to expose this query string. But I prefer adding a patch in `SwaggerConfig.cs` in order to avoid potential conflicts in the future.

-------------
The usage of `appName` is to specify the deployment destination. By default is `ROOT`, which means the application can be accessed by `aaa.bbb.com/`.

If its value is other than `ROOT`, for example, `test`. Then after deployment, the application can be accessed by `aaa.ccc.com/test/`.